### PR TITLE
Fix shooter to compile

### DIFF
--- a/src/Subsystems/Shooter.h
+++ b/src/Subsystems/Shooter.h
@@ -1,8 +1,8 @@
 #ifndef Shooter_H
 #define Shooter_H
 
-#include "Commands/Subsystem.h"
-#include "CANTalon.h"
+#include <Commands/Subsystem.h>
+#include <CANTalon.h>
 
 #include "Commands/SetShooter.h"
 


### PR DESCRIPTION
Fix the includes so that Shooter compiles.

The `<>` around the FRC includes allow the code to compile properly.